### PR TITLE
Lower to (and stay at) minimumRate

### DIFF
--- a/strategies/updateLoan/index.js
+++ b/strategies/updateLoan/index.js
@@ -17,6 +17,9 @@ module.exports.lowerRateWithTime = function(offer, data, settings, exchangeName,
         if (settings.minimumRate < offer.rate) {
             offer.action = 'update';
         }
+        else {
+            offer.rate = settings.minimumRate;
+        }
     }
 
     cb(null, offer);

--- a/strategies/updateLoan/index.js
+++ b/strategies/updateLoan/index.js
@@ -13,18 +13,10 @@ module.exports.lowerRateWithTime = function(offer, data, settings, exchangeName,
     // If the loan is older than 'lowerAfterMinutes' old and is still higher than the 'targetRate',
     // make a new loan with the rate lowered by 'lowerByPercent'
     if (age > settings.rateUpdateStrategy.lowerAfterMinutes) {
-	if (offer.rate > data.targetRate) {
-	    offer.rate = data.targetRate;
-	}
-	else {
-	    offer.rate = offer.rate - (offer.rate * settings.rateUpdateStrategy.lowerByPercent / 100);
-	}
-	offer.action = 'update';
-    }
-
-    // cancel if we are now below our minimum rate
-    if (offer.rate < settings.minimumRate) {
-	offer.action = 'cancel';
+        offer.rate = offer.rate - (offer.rate * settings.rateUpdateStrategy.lowerByPercent / 100);
+        if (settings.minimumRate < offer.rate) {
+            offer.action = 'update';
+        }
     }
 
     cb(null, offer);


### PR DESCRIPTION
Allow orders to move below targetRate until they reach minimumRate.

This is useful in conjunction with staticRate strategy, but also seems more sensible if the goal is to get the order filled (targetRate might fluctuate).

Perhaps this should be made into a separate strategy, but to me it seems like a more useful behavior.